### PR TITLE
fix: Add missing typing imports and update Docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Navigate to the root directory of the project (where the `Dockerfile` is located
 ```bash
 docker build -t blast-gui-app .
 ```
-This will create a Docker image named `blast-gui-app`.
+This will create a Docker image named `blast-gui-app`. If you pull new changes for `app.py` or other project files from the repository later, you will need to re-run this `docker build` command to update your local image with those changes.
 
 **Step 3: Configure X Server Access (Crucial for GUI Display)**
 

--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ import requests
 import time
 import xml.etree.ElementTree as ET
 import threading
+from typing import Optional, Dict, List, Tuple # Added this import
 
 # --- Suppress NotOpenSSLWarning ---
 import warnings


### PR DESCRIPTION
- Added `from typing import Optional, Dict, List, Tuple` to app.py to resolve NameError during Docker execution.
- Updated README.md to advise you to rebuild the Docker image after fetching code updates.